### PR TITLE
fix: restrict Route53 upsert records

### DIFF
--- a/src/EcsTask.ts
+++ b/src/EcsTask.ts
@@ -175,6 +175,12 @@ export class EcsTask extends Construct {
         sid: "AllowRoute53Updates",
         actions: ["route53:ChangeResourceRecordSets"],
         resources: [`arn:aws:route53:::hostedzone/${hostedZone.hostedZoneId}`],
+        conditions: {
+          StringEquals: {
+            "route53:ChangeResourceRecordSetsActions": ["UPSERT"],
+            "route53:ChangeResourceRecordSetsNormalizedRecordNames": [wordpressDomain],
+          },
+        },
       })
     );
     taskDefinition.addToTaskRolePolicy(


### PR DESCRIPTION
This prevents a malicious actor using this role from mutating records they shouldn't have access to.