### PR TITLE
fix: resolve issues with net-new sites

### DIFF
--- a/API.md
+++ b/API.md
@@ -55,7 +55,8 @@ you’re done you shut down the Wordpress container and it costs you almost noth
 
 1. Deploy with the [`cdk deploy` command](https://docs.aws.amazon.com/cdk/v2/guide/cli.html#cli-deploy)
 1. Once the deployment completes, visit the Wordpress console at `admin-<fullyQualifiedSiteName>`. E.g., if your static
-   site is `blog.example.com`, visit `admin-blog.example.com/wp-admin`.
+   site is `blog.example.com`, visit `admin-blog.example.com/wp-admin`. The default password for the wordpress user
+   is `changeme` (please change it :smile:).
 1. Customize Wordpress as you see fit, create posts, etc.
 1. When you're ready to deploy your static site, trigger WP2Static.
 
@@ -2784,7 +2785,7 @@ const wordpressAdminProps: WordpressAdminProps = { ... }
 | <code><a href="#@blimmer/cdk-static-wordpress.WordpressAdminProps.property.email">email</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@blimmer/cdk-static-wordpress.WordpressAdminProps.property.domainPrefix">domainPrefix</a></code> | <code>string</code> | The prefix to use for the non-static admin site. |
 | <code><a href="#@blimmer/cdk-static-wordpress.WordpressAdminProps.property.ecsOverrides">ecsOverrides</a></code> | <code><a href="#@blimmer/cdk-static-wordpress.EcsOverrides">EcsOverrides</a></code> | [ADVANCED] Override various aspects of the ECS infrastructure. |
-| <code><a href="#@blimmer/cdk-static-wordpress.WordpressAdminProps.property.password">password</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@blimmer/cdk-static-wordpress.WordpressAdminProps.property.password">password</a></code> | <code>string</code> | The password to use for the admin user. |
 | <code><a href="#@blimmer/cdk-static-wordpress.WordpressAdminProps.property.run">run</a></code> | <code>boolean</code> | Should we run the Wordpress admin console? |
 | <code><a href="#@blimmer/cdk-static-wordpress.WordpressAdminProps.property.username">username</a></code> | <code>string</code> | *No description.* |
 
@@ -2835,6 +2836,9 @@ public readonly password: string;
 ```
 
 - *Type:* string
+- *Default:* changeme
+
+The password to use for the admin user.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ you’re done you shut down the Wordpress container and it costs you almost noth
 
 1. Deploy with the [`cdk deploy` command](https://docs.aws.amazon.com/cdk/v2/guide/cli.html#cli-deploy)
 1. Once the deployment completes, visit the Wordpress console at `admin-<fullyQualifiedSiteName>`. E.g., if your static
-   site is `blog.example.com`, visit `admin-blog.example.com/wp-admin`.
+   site is `blog.example.com`, visit `admin-blog.example.com/wp-admin`. The default password for the wordpress user
+   is `changeme` (please change it :smile:).
 1. Customize Wordpress as you see fit, create posts, etc.
 1. When you're ready to deploy your static site, trigger WP2Static.
 

--- a/assets/WordpressDockerImage/docker-entrypoint.sh
+++ b/assets/WordpressDockerImage/docker-entrypoint.sh
@@ -314,12 +314,24 @@ echo "$(sudo -u www-data wp plugin list)"
 # Install WP2Static and S3 Add-on
 if ! sudo -u www-data wp plugin is-installed wp2static || [ "$(sudo -u www-data wp plugin get wp2static --field=version)" != "$WP2STATIC_VERSION" ]; then
 	echo "Installing or updating WP2Static..."
-	sudo -u www-data wp plugin install /tmp/serverless-wordpress-wp2static.zip --activate --path=/var/www/html || true
+	sudo -u www-data wp plugin install /tmp/serverless-wordpress-wp2static.zip --activate --path=/var/www/html
 fi
+
 if ! sudo -u www-data wp plugin is-installed wp2static-addon-s3 || [ "$(sudo -u www-data wp plugin get wp2static-addon-s3 --field=version)" != "$WP2STATIC_S3_ADDON_VERSION" ]; then
 	echo "Installing or updating WP2Static S3 Add-on..."
-	sudo -u www-data wp plugin install /tmp/serverless-wordpress-s3-addon.zip --activate --path=/var/www/html || true
+	sudo -u www-data wp plugin install /tmp/serverless-wordpress-s3-addon.zip --activate --path=/var/www/html
 fi
+
+if ! sudo -u www-data wp plugin is-active wp2static; then
+  echo "Activating WP2Static..."
+  sudo -u www-data wp plugin activate wp2static
+fi
+
+if ! sudo -u www-data wp plugin is-active wp2static-addon-s3; then
+  echo "Activating WP2Static S3 Add-on..."
+  sudo -u www-data wp plugin activate wp2static-addon-s3
+fi
+
 # Update WP_MEMORY_LIMIT
 sudo -u www-data wp config set WP_MEMORY_LIMIT ${WP_MEMORY_LIMIT}
 # # Update Wordpress options with IP of running container
@@ -328,7 +340,7 @@ sudo -u www-data wp option update home "http://${CONTAINER_DNS}" || true
 
 # If environment variables for S3 static output is set, populate it in the plugin
 if [ "${WPSTATIC_DEST-}" ]; then
-    sudo -u www-data wp wp2static options set deploymentURL $WPSTATIC_DEST || true
+  sudo -u www-data wp wp2static options set deploymentURL $WPSTATIC_DEST || true
 	sudo -u www-data wp db query "UPDATE wp_wp2static_addons SET enabled = 1 WHERE slug = 'wp2static-addon-s3';"
 fi
 if [ "${WPSTATIC_REGION-}" ]; then

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,11 @@ import { TaskDefinitionOverrides } from "./generated/TaskDefinitionOverrides";
 export interface WordpressAdminProps {
   readonly email: string;
   readonly username?: string;
+  /**
+   * The password to use for the admin user.
+   *
+   * @default - changeme
+   */
   readonly password?: string; // TODO: or secretsmanager secret
 
   /**


### PR DESCRIPTION
@yuexuan reported several issues with creating a new site in #28. I realized that some of my updates worked on my site because Wordpress was already activated. I was able to reproduce the issues reported in #28 on a net-new site.

The main issues appear to be with wp-cli (which I've updated). See inline comments for details.

Fixes #28 
